### PR TITLE
Add commonec2 policy

### DIFF
--- a/examples/commonec2/README.md
+++ b/examples/commonec2/README.md
@@ -1,0 +1,11 @@
+# commonec2 Example
+Configuration in this directory creates an AWS IAM role for commonec2
+
+## Usage
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```

--- a/examples/commonec2/README.md
+++ b/examples/commonec2/README.md
@@ -1,5 +1,5 @@
 # commonec2 Example
-Configuration in this directory creates an AWS IAM role for commonec2
+Configuration in this directory creates an AWS IAM role for commonec2. It also create customer-managed policy which will be attached to the IAM role.
 
 ## Usage
 To run this example you need to execute:

--- a/examples/commonec2/README.md
+++ b/examples/commonec2/README.md
@@ -1,5 +1,5 @@
 # commonec2 Example
-Configuration in this directory creates an AWS IAM role for commonec2. It also create customer-managed policy which will be attached to the IAM role.
+Configuration in this directory creates an AWS IAM role for commonec2. It also create customer-managed policy which will be attached to the IAM role. Commonec2 policy is a list of policy that commonly used in multi-account. This policy need to be provided before you launch your service in multi-account.
 
 ## Usage
 To run this example you need to execute:

--- a/examples/commonec2/README.md
+++ b/examples/commonec2/README.md
@@ -1,5 +1,5 @@
 # commonec2 Example
-Configuration in this directory creates an AWS IAM role for commonec2. It also create customer-managed policy which will be attached to the IAM role. Commonec2 policy is a list of policy that commonly used in multi-account. This policy need to be provided before you launch your service in multi-account.
+This is an example of usage of `commonec2` module, the configuration in this directory creates an AWS IAM Role for commonly used by EC2 we called it `commonec2`. This module also create customer-managed policy which will be attached to the IAM role. This policy need to be provided before you launch your service in multi-account.
 
 ## Usage
 To run this example you need to execute:

--- a/examples/commonec2/main.tf
+++ b/examples/commonec2/main.tf
@@ -1,0 +1,22 @@
+# Create IAM Role
+module "aws-iam-role_commonec2" {
+  source  = "traveloka/iam-role/aws//modules/instance/"
+  version = "v1.0.2"
+
+  product_domain = "tsi"
+  service_name   = "tsicwa"
+  cluster_role   = "app"
+  environment    = "staging"
+}
+
+# Create IAM Policy, using this module
+module "aws-common-iam-policies_commonec2" {
+  source = "../../modules/commonec2/"
+}
+
+# Attach the policy to the role as inline policy
+resource "aws_iam_role_policy" "commonec2" {
+  name   = "commonec2"
+  role   = "${module.aws-iam-role_commonec2.role_name}"
+  policy = "${module.aws-common-iam-policies_commonec2.policy_json}"
+}

--- a/modules/commonec2/README.md
+++ b/modules/commonec2/README.md
@@ -1,5 +1,5 @@
 # terraform-aws-common-iam-policies/commonec2
-This module is meant to create an IAM Policy for commonec2.
+This module is meant to create an IAM Policy for commonec2. Commonec2 policy is a list of policy that commonly used in multi-account.
 
 ## Usage
 

--- a/modules/commonec2/README.md
+++ b/modules/commonec2/README.md
@@ -1,5 +1,5 @@
 # terraform-aws-common-iam-policies/commonec2
-This module is meant to create an IAM Policy for commonec2. Commonec2 policy is a list of policy that commonly used in multi-account.
+This module is meant to create an IAM Policy for commonec2. Commonec2 policy is a list of policy that commonly used in multi-account. This policy need to be provided before you launch your service in multi-account.
 
 ## Usage
 

--- a/modules/commonec2/README.md
+++ b/modules/commonec2/README.md
@@ -1,5 +1,5 @@
 # terraform-aws-common-iam-policies/commonec2
-This module is meant to create an IAM Policy for commonec2. Commonec2 policy is a list of policy that commonly used in multi-account. This policy need to be provided before you launch your service in multi-account.
+This module is meant to create an IAM Policy for commonly used policy on EC2 we called it `commonec2`. This policy need to be provided before you launch your service in multi-account.
 
 ## Usage
 

--- a/modules/commonec2/README.md
+++ b/modules/commonec2/README.md
@@ -1,0 +1,13 @@
+# terraform-aws-common-iam-policies/commonec2
+This module is meant to create an IAM Policy for commonec2.
+
+## Usage
+
+You can open this example:
+- [commonec2](https://github.com/traveloka/terraform-aws-common-iam-policies/tree/master/examples/commonec2)
+
+## Authors
+- [Hierony Manurung](https://github.com/HieronyM)
+
+## License
+Apache 2 Licensed. See [../../LICENSE](../../LICENSE) for full details.

--- a/modules/commonec2/main.tf
+++ b/modules/commonec2/main.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "policy" {
+  statement {
+    sid = "1"
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:CreateLogGroup",
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+  
+  statement {
+    sid = "2"
+    effect = "Allow"
+
+    actions = [
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+      "logs:FilterLogEvents",
+      "logs:PutRetentionPolicy",
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+
+}

--- a/modules/commonec2/outputs.tf
+++ b/modules/commonec2/outputs.tf
@@ -1,0 +1,4 @@
+output "policy_json" {
+  description = "An IAM Policy in JSON format"
+  value       = "${data.aws_iam_policy_document.policy.json}"
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Background

We need to to change our logging agent to **[Cloudwatch-agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html)**, we decided to use the new agent because:
 - AWS recommended to use new agent
 - Cloudwatch-agent support metrics collection. We want to collect memory metric to be used as metric for performance recommendation engine in AWS Cost Explorer and for scaling policy in our app.

Since we want to deploy the agent in multi-account, We need to create module to provide the common policy. This PR provides the commonec2 policy as the prerequisites to deploy the agent in multi-account. This changes will update this specific documentation [Common IAM Policies](https://29022131.atlassian.net/wiki/spaces/SI/pages/187947145/IAM+Policies).

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #2 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-common-iam-policies/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* NONE

FEATURES:

* Add commonec2 policy (#2 )
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
