### PR TITLE
add permissions in PDBM for postgres proxy publishing related things

### DIFF
--- a/modules/product-domain-build-manager/main.tf
+++ b/modules/product-domain-build-manager/main.tf
@@ -344,6 +344,8 @@ data "aws_iam_policy_document" "policy" {
       "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/ami-baking/${var.product_domain}/*",
       "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/java-build-shared-resources/pd/${var.product_domain}/*",
       "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/java-build/${var.product_domain}/*",
+      "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/postgres-proxy-publishing-shared-resources/pd/${var.product_domain}/*",
+      "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/postgres-proxy-publishing/${var.product_domain}/*",
     ]
   }
 
@@ -359,6 +361,7 @@ data "aws_iam_policy_document" "policy" {
     resources = [
       "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/ami-baking/${var.product_domain}/*",
       "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/java-build/${var.product_domain}/*",
+      "arn:aws:s3:::${var.terraform_state_bucket_name}/${data.aws_region.current.name}/postgres-proxy-publishing/${var.product_domain}/*",
     ]
   }
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-common-iam-policies/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:
* NONE

ENHANCEMENTS:

* feature: Allow PDBM to modify terraform state for postgres-proxy-publishing pipelines
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
